### PR TITLE
feat:ユーザーごとの認証を実装

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 *.pyc
 *.pyo
 
+# Firebase認証情報
+secrets/
+
 # その他のPython関連キャッシュ
 *.pyd
 *.pdb

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,16 +5,20 @@ from sqlalchemy.orm import sessionmaker
 import stripe 
 from datetime import datetime
 from app.tasks import update_usage  # tasks.pyからupdate_usageタスクをインポート@app.post("/start-usage/")
-from app.routers import users  # usersルーターをインポート
+from app.routers import users  # users.py ルーターをインポート
+from app.routers import auth  # auth.py をインポート
 from app.db import init_db
 from contextlib import asynccontextmanager
+from app.middleware import add_cors_middleware
 
 stripe.api_key = 'sk_test_51Qpl1SJzpJ9UCOiVkKPGfNqfPkzMQsHYN8x2XKFpAvk4gpj2DyMo6shH6fD7LuKdKYW4ynl2eyPbGAMZzKOHh4Fb00yeVnWvpv'
 
 
 app = FastAPI()
 
+app.include_router(auth.router)
 app.include_router(users.router)
+add_cors_middleware(app)
 
 # PostgreSQLへの接続設定
 DATABASE_URL = "postgresql://postgres:password@host.docker.internal:5432/mydatabase"

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,11 @@
+from fastapi.middleware.cors import CORSMiddleware
+
+def add_cors_middleware(app):
+    """CORSミドルウェアをアプリケーションに追加する"""
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],  # フロントエンドのURLを指定（開発中は * でもOK）
+        allow_credentials=True,
+        allow_methods=["*"],  # すべてのHTTPメソッドを許可
+        allow_headers=["*"],  # すべてのヘッダーを許可
+    )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,25 @@
+#既存ユーザーログイン認証(POST)
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+from app.utils.firebase_auth import verify_firebase_token
+from app.db import get_db
+from app.models import User
+from app.schemas import UserResponse
+from pydantic import BaseModel
+
+router = APIRouter()
+
+class LoginRequest(BaseModel):
+    id_token: str
+
+@router.post("/login", response_model=UserResponse)
+def login(request: LoginRequest, db: Session = Depends(get_db)):
+    """FirebaseのIDトークンを検証し、ユーザーを認証"""
+    firebase_uid = verify_firebase_token(request.id_token)
+
+    # ユーザーが存在するか確認
+    user = db.query(User).filter(User.firebase_uid == firebase_uid).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="ユーザーが見つかりません")
+
+    return user

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -1,15 +1,17 @@
+#新規ユーザー登録 & 取得(GET/POST)
 from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import func
 from app.db import get_db
 from app.models import User  # SQLAlchemyのUserモデルをインポート
 from app.schemas import UserCreate, UserResponse  # Pydanticのスキーマをインポート
-from sqlalchemy.sql import func
+from app.utils.firebase_auth import verify_firebase_token
 
 router = APIRouter()
 
-#POST（新規ユーザーの登録）
-@router.post("/users", response_model=UserResponse)
-def create_user(user: UserCreate, db: Session = Depends(get_db)):
+@router.post("/register", response_model=UserResponse)
+def register(user: UserCreate, db: Session = Depends(get_db)):
+    """新規ユーザー登録（Firebase UIDと共にデータベースへ保存）"""
     # 既存のメールアドレスがあるかチェック
     existing_user = db.query(User).filter(User.email == user.email).first()
     if existing_user:
@@ -19,11 +21,11 @@ def create_user(user: UserCreate, db: Session = Depends(get_db)):
         firebase_uid=user.firebase_uid,
         first_name=user.first_name,
         last_name=user.last_name,
-        address=user.address,
-        phone_number=user.phone_number,
         email=user.email,
-        created_at=user.created_at or func.now(),
-        updated_at=user.updated_at or func.now()
+        phone_number=user.phone_number,
+        address=user.address,
+        created_at=func.now(),
+        updated_at=func.now()
     )
     db.add(db_user)
     db.commit()
@@ -35,3 +37,14 @@ def create_user(user: UserCreate, db: Session = Depends(get_db)):
 def get_users(db: Session = Depends(get_db)):
     users = db.query(User).all()
     return users
+
+@router.get("/users/me", response_model=UserResponse)
+def get_me(id_token: str, db: Session = Depends(get_db)):
+    """現在ログイン中のユーザー情報を取得"""
+    firebase_uid = verify_firebase_token(id_token)
+
+    user = db.query(User).filter(User.firebase_uid == firebase_uid).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="ユーザーが見つかりません")
+
+    return user

--- a/backend/app/utils/firebase_auth.py
+++ b/backend/app/utils/firebase_auth.py
@@ -1,0 +1,26 @@
+import os
+import firebase_admin
+from firebase_admin import credentials, auth
+from fastapi import HTTPException
+
+# 環境変数からGOOGLE_APPLICATION_CREDENTIALSのパスを取得
+firebase_credentials_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+if firebase_credentials_path is None:
+    raise ValueError("GOOGLE_APPLICATION_CREDENTIALS環境変数が設定されていません。")
+
+# Firebaseの認証設定
+cred = credentials.Certificate(firebase_credentials_path)
+firebase_admin.initialize_app(cred)
+
+def verify_firebase_token(id_token: str) -> str:
+    """FirebaseのIDトークンを検証し、UIDを取得する"""
+    try:
+        decoded_token = auth.verify_id_token(id_token, clock_skew_seconds=60) # 時刻ズレ許容
+        return decoded_token["uid"]
+    except auth.ExpiredIdTokenError:
+        raise HTTPException(status_code=401, detail="トークンが期限切れです。もう一度ログインしてください。")
+    except auth.InvalidIdTokenError:
+        raise HTTPException(status_code=401, detail="無効なトークンです。")
+    except Exception as e:
+        raise HTTPException(status_code=401, detail=f"認証エラー: {str(e)}")

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -18,10 +18,13 @@ services:
       - postgres
     environment:
       - DATABASE_URL=postgresql://postgres:password@host.docker.internal:5432/mydatabase
+    env_file:
+      - .env
     ports:
       - "8000:8000"
     volumes:
       - .:/app
+      - ./app/secrets:/app/secrets
     command:
       [
         "uvicorn",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -61,4 +61,3 @@ alembic
 psycopg2
 stripe
 celery
-email-validator

--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -20,10 +20,34 @@ export default function Login() {
     setError(''); // エラーメッセージをリセット
 
     try {
-      await signInWithEmailAndPassword(auth, email, password);
-      router.push('/rental'); // ログイン成功時に `/rental` へ遷移
+      // Firebase認証を行い、IDトークンを取得
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password,
+      );
+      const user = userCredential.user;
+      const token = await user.getIdToken();
+
+      // IDトークンをバックエンドに送信
+      const response = await fetch('http://localhost:8000/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ id_token: token }),
+      });
+
+      const data = await response.json();
+      console.log(data); // レスポンスデータの内容をログに出力
+
+      // レスポンスをチェック
+      if (response.ok) {
+        router.push('/rental'); // ログイン成功時に `/rental` へ遷移
+      } else {
+        setError('ログイン失敗');
+      }
     } catch (error) {
-      setError('正しい内容を入力してください'); // エラーメッセージを設定
       console.error(error);
     }
   };
@@ -54,12 +78,7 @@ export default function Login() {
         />
 
         {/* ログインボタン */}
-        <Button
-          type="submit"
-          className="bg-blue-500 text-white hover:bg-blue-700"
-        >
-          ログイン
-        </Button>
+        <Button type="submit">ログイン</Button>
       </form>
 
       {/* 新規登録ページへのリンク */}

--- a/frontend/src/lib/firebase.ts
+++ b/frontend/src/lib/firebase.ts
@@ -1,6 +1,11 @@
 import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
+import {
+  getAuth,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+} from 'firebase/auth';
 
+// Firebaseの設定
 const firebaseConfig = {
   apiKey: 'AIzaSyDPhLALDOEFlS-JhsJbqs8lvp-bkSwaWwc',
   authDomain: 'chariho.firebaseapp.com',
@@ -13,3 +18,45 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
+
+// メールアドレスとパスワードでサインインする関数
+export async function signInWithEmail(email: string, password: string) {
+  try {
+    const userCredential = await signInWithEmailAndPassword(
+      auth,
+      email,
+      password,
+    );
+    const user = userCredential.user;
+    // サインイン後にIDトークンを取得
+    const token = await user.getIdToken();
+    return token; // トークンを返す
+  } catch (error) {
+    console.error(
+      'メールアドレスまたはパスワードが間違っています。再度確認してください。',
+      error,
+    );
+    throw error; // エラーを呼び出し元に投げる
+  }
+}
+
+// 新規ユーザー登録のための関数
+export async function signUpWithEmail(email: string, password: string) {
+  try {
+    const userCredential = await createUserWithEmailAndPassword(
+      auth,
+      email,
+      password,
+    );
+    const user = userCredential.user;
+    // サインイン後にIDトークンを取得
+    const token = await user.getIdToken();
+    return token; // トークンを返す
+  } catch (error) {
+    console.error(
+      'このメールアドレスは既に使用されています。別のメールアドレスを試してください。',
+      error,
+    );
+    throw error; // エラーを呼び出し元に投げる
+  }
+}


### PR DESCRIPTION
## issue 番号
#32
#33
#34 
## やったこと
・FirebaseSDKでフロントエンドとバックエンドの統合
・新規登録→DBに情報保存→ログインページでログイン（トークン検証）
## 特にレビューして欲しい箇所

## 動作確認(スクショ等)
![スクリーンショット 2025-02-18 192749](https://github.com/user-attachments/assets/8422a0d1-e7d3-4c82-bb48-ba1de09a78bd)
![スクリーンショット 2025-02-18 192814](https://github.com/user-attachments/assets/92a59af8-7bef-467b-b65f-b3864da821fa)
![スクリーンショット 2025-02-18 192831](https://github.com/user-attachments/assets/59ae06f8-b049-456a-b406-9dceef6fb9b7)
![スクリーンショット 2025-02-18 195906](https://github.com/user-attachments/assets/5f1fa545-da5f-44e2-b8e3-264e6be52d1b)

## その他
