### PR TITLE
doc:グーグルマップとヘッダーの修正

### DIFF
--- a/frontend/src/app/components/Header.tsx
+++ b/frontend/src/app/components/Header.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 export default function Header() {
   return (
-    <header className="fixed w-full flex justify-between items-center px-8 py-4 shadow-md bg-[#81d4fa]">
+    <header className="fixed w-full flex justify-between items-center px-8 py-4 shadow-md bg-[#81d4fa] z-20">
       {/* 左側: アプリ名 */}
       <Link
         href="/"

--- a/frontend/src/app/rental/return/page.tsx
+++ b/frontend/src/app/rental/return/page.tsx
@@ -70,8 +70,8 @@ export default function ReturnPage() {
         )}
 
         {/* Googleマップエリア */}
-        <div className="mt-6 w-full flex justify-center">
-          <div className="w-4/5 h-[300px] rounded-lg border overflow-hidden">
+        <div className="relative mt-6 w-full flex justify-center">
+          <div className="w-4/5 h-[300px] rounded-lg border overflow-hidden z-0">
             <GoogleMapComponent
               center={storageLocation}
               zoom={15}


### PR DESCRIPTION
## issue 番号
#86 
## やったこと
グーグルマップがヘッダーに被らないように修正しました。
## 特にレビューして欲しい箇所

## 動作確認(スクショ等)
![スクリーンショット (56)](https://github.com/user-attachments/assets/85fdc5c2-b941-4f69-89ee-a5aabb9c2bfd)

## その他
