### PR TITLE
feat:返却ページの画像をfirebasestorageに保存

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from app.routers import users  # users.py ルーターをインポート
 from app.routers import auth  # auth.py をインポート
 from app.routers import webhook  # webhook.py をインポート
 from app.routers import checkout  # checkout.py をインポート
+from app.routers import upload
 from contextlib import asynccontextmanager
 from app.db import init_db
 from app.middleware import add_cors_middleware
@@ -17,6 +18,7 @@ app.include_router(auth.router)
 app.include_router(users.router)
 app.include_router(webhook.router)
 app.include_router(checkout.router)
+app.include_router(upload.router)
 add_cors_middleware(app)
 
 # PostgreSQLへの接続設定

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -1,0 +1,22 @@
+# app/routers/upload.py
+from fastapi import APIRouter, File, UploadFile, Header, HTTPException
+from app.utils.firebase_auth import verify_firebase_token
+from app.utils.firebase_storage import upload_image
+
+router = APIRouter()
+
+@router.post("/upload-image/")
+async def upload_image_api(
+    file: UploadFile = File(...), authorization: str = Header(None)
+):
+    """画像を Firebase Storage にアップロードし、URL を返す"""
+    if not authorization:
+        raise HTTPException(status_code=401, detail="認証トークンが必要です")
+    
+    # Firebase のトークンを検証して UID を取得
+    user_id = verify_firebase_token(authorization.split(" ")[1])
+
+    # 画像をアップロードして URL を取得
+    image_url = upload_image(file, user_id)
+
+    return {"image_url": image_url}

--- a/backend/app/utils/firebase_storage.py
+++ b/backend/app/utils/firebase_storage.py
@@ -1,0 +1,34 @@
+import os
+import firebase_admin
+from firebase_admin import storage
+from fastapi import HTTPException, UploadFile
+from datetime import datetime
+import uuid
+
+# 環境変数から Firebase のバケット名を取得
+FIREBASE_STORAGE_BUCKET = os.getenv("FIREBASE_STORAGE_BUCKET")
+
+if FIREBASE_STORAGE_BUCKET is None:
+    raise ValueError("FIREBASE_STORAGE_BUCKET 環境変数が設定されていません。")
+
+# Firebase Storage の設定
+bucket = storage.bucket(FIREBASE_STORAGE_BUCKET)
+
+
+def upload_image(file: UploadFile, user_id: str) -> str:
+    """Firebase Storage に画像をアップロードし、URL を返す"""
+    try:
+        # 一意のファイル名を作成
+        file_extension = file.filename.split(".")[-1]
+        unique_filename = f"{uuid.uuid4()}.{file_extension}"
+        blob_path = f"{user_id}/{unique_filename}"  # ユーザーごとのフォルダに保存
+
+        # バケットにアップロード
+        blob = bucket.blob(blob_path)
+        blob.upload_from_file(file.file, content_type=file.content_type)
+
+        # ファイルの公開 URL を取得
+        blob.make_public()
+        return blob.public_url
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"画像のアップロードに失敗しました: {str(e)}")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -61,3 +61,4 @@ alembic
 psycopg2
 stripe
 celery
+python-multipart

--- a/frontend/src/app/rental/return/page.tsx
+++ b/frontend/src/app/rental/return/page.tsx
@@ -11,7 +11,7 @@ import CameraUploader from '@/app/components/CameraUploader';
 import Link from 'next/link';
 
 // 仮の現在地
-const storageLocation = { lat: 34.6947584, lng: 135.528448 }; //返却可能
+const storageLocation = { lat: 35.3959936, lng: 136.6228992 }; //返却可能
 
 // 返却可能な誤差範囲（±10m ≒ 0.00009度）
 const LAT_LNG_THRESHOLD = 0.00009;


### PR DESCRIPTION
## issue 番号
#103 
## やったこと
返却時にアップロードした画像をfirebasestorageに保存する
## 特にレビューして欲しい箇所

## 動作確認(スクショ等)
![スクリーンショット (65)](https://github.com/user-attachments/assets/099359f9-713d-4fcc-a12f-0668bc444f2f)

## その他
